### PR TITLE
feat: Added filtering for staff id in tasks page

### DIFF
--- a/src/api/tasks/queries.ts
+++ b/src/api/tasks/queries.ts
@@ -15,10 +15,15 @@ export async function getAllClientTasks(): Promise<Result<ClientTasks[]>> {
   }
 
   try {
-    const filtered_clients = await db.query.clients.findMany({
-      with: { tasks: true },
-      where: eq(clients.staffId, session.user.id),
-    });
+    const filtered_clients =
+      session.user.role == "admin"
+        ? await db.query.clients.findMany({
+            with: { tasks: true },
+          })
+        : await db.query.clients.findMany({
+            with: { tasks: true },
+            where: eq(clients.staffId, session.user.id),
+          });
     return [filtered_clients, null];
   } catch (error) {
     return [null, handleError(error)];


### PR DESCRIPTION
# Description
I added the code needed to filter tasks based on currently logged in user id. If an admin is logged in, then they will see all clients instead.

## Relevant Issues
#78 

## How to Test
Go to tasks page and see users there.

## Miscellaneous Notes
I created duplicate users for every person in our team so they all had access to users if they needed to work on the tasks page, but because of that, each email for each duplicate user had to be unique which the easiest way to fix was by adding the id at the start of the original data entries' emails. The emails are now quite big on the tasks page, so let me know if you want me to change those to something shorter, but otherwise the filtering does work.