### PR TITLE
feat: Added confirmation page

### DIFF
--- a/src/components/intake-form/confirmation-form/confirmation-form-schema.ts
+++ b/src/components/intake-form/confirmation-form/confirmation-form-schema.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const confirmationFormSchema = z.object({
+  residentConfirmation: z.boolean().refine((val) => val === true, {
+    message: "Must confirm pdf is accurate",
+  }),
+});
+
+export type ConfirmationFormValues = z.infer<typeof confirmationFormSchema>;
+
+export const confirmationFormDefaultValues: ConfirmationFormValues = {
+  residentConfirmation: false,
+};

--- a/src/components/intake-form/confirmation-form/index.tsx
+++ b/src/components/intake-form/confirmation-form/index.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { Box, Typography } from "@mui/material";
+import Checkbox from "@mui/material/Checkbox";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import { ReactNode, useEffect, useState } from "react";
+import { Controller, useFormContext } from "react-hook-form";
+
+import DocumentDisplay from "@/components/common/document-display";
+import { useIntakeFormContext } from "@/providers/intake-form-provider";
+
+import { IntakeFormValues } from "../intake-form-schema";
+
+export default function ConfirmationForm(): ReactNode {
+  const { getIntakeFormPdfUrl } = useIntakeFormContext();
+  const [confirmationPdfUrl, setConfirmationPdfUrl] = useState("");
+  useEffect(() => {
+    // const fetchPdf = async () => {
+    async function fetchPdf(): Promise<void> {
+      try {
+        const url = await getIntakeFormPdfUrl(); // The first promise
+        setConfirmationPdfUrl(url);
+      } catch (error) {
+        console.error("Failed to get PDF URL:", error);
+      }
+    }
+
+    void fetchPdf();
+  }, [getIntakeFormPdfUrl]);
+  const {
+    control,
+    formState: { errors },
+  } = useFormContext<IntakeFormValues>();
+  // const pdfUrl = getIntakeFormPdfUrl().then();
+  return (
+    <Box sx={{ width: "100%" }}>
+      <Typography variant="h5" sx={{ mb: 2, textAlign: "center" }}>
+        Confirm Details
+      </Typography>
+      <DocumentDisplay pdfUrl={confirmationPdfUrl} />
+      <Controller
+        control={control}
+        name={"confirmation.residentConfirmation"}
+        render={({ field }) => (
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+            }}
+          >
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={!!field.value}
+                  onChange={(e) => field.onChange(e.target.checked)}
+                />
+              }
+              label="I have reviewed the following document and I agree to all the information provided"
+            />
+            {errors["confirmation"]?.residentConfirmation && (
+              <Box sx={{ color: "error.main", mt: 1, fontSize: "0.875rem" }}>
+                {errors.confirmation?.residentConfirmation.message}
+              </Box>
+            )}
+          </Box>
+        )}
+      />
+    </Box>
+  );
+}

--- a/src/components/intake-form/index.tsx
+++ b/src/components/intake-form/index.tsx
@@ -11,6 +11,7 @@ import { useIntakeFormContext } from "@/providers/intake-form-provider";
 
 import BehavioralStandardsForm from "./behavioral-standards-form";
 import ConfidentialityAgreementForm from "./confidentiality-agreement-form";
+import ConfirmationForm from "./confirmation-form";
 import DemographicForm from "./demographic-form";
 import EmergencyContactForm from "./emergency-contact-form";
 import FinancialResponsibilityForm from "./financial-responsibility-form";
@@ -77,6 +78,10 @@ const intakeFormSteps: IntakeFormStep[] = [
   {
     name: "emergencyContact",
     form: <EmergencyContactForm />,
+  },
+  {
+    name: "confirmation",
+    form: <ConfirmationForm />,
   },
 ];
 

--- a/src/components/intake-form/intake-form-schema.ts
+++ b/src/components/intake-form/intake-form-schema.ts
@@ -9,6 +9,10 @@ import {
   confidentialityAgreementFormSchema,
 } from "./confidentiality-agreement-form/confidentiality-agreement-form-schema";
 import {
+  confirmationFormDefaultValues,
+  confirmationFormSchema,
+} from "./confirmation-form/confirmation-form-schema";
+import {
   demographicFormDefaultValues,
   demographicFormSchema,
 } from "./demographic-form/demographic-form-schema";
@@ -57,6 +61,7 @@ export const intakeFormSchema = z.object({
   releaseOfInformation: releaseOfInformationFormSchema,
   serviceContract: serviceContractFormSchema,
   temporaryResidency: temporaryResidencyFormSchema,
+  confirmation: confirmationFormSchema,
 });
 
 export type IntakeFormValues = z.infer<typeof intakeFormSchema>;
@@ -73,6 +78,7 @@ export const intakeFormDefaultValues: IntakeFormValues = {
   releaseOfInformation: releaseOfInformationFormDefaultValues,
   serviceContract: serviceContractFormDefaultValues,
   temporaryResidency: temporaryResidencyFormDefaultValues,
+  confirmation: confirmationFormDefaultValues,
 };
 
 // Get all the forms that have the residentSignature and staffSignature fields


### PR DESCRIPTION
# Description
I added the confirmation page that shows the entire pdf of all forms together and the checkbox to confirm everything looks good before being able to submit and download the final pdf.

## Relevant Issues
#91 

## How to Test
Go to end of intake form to see the confirmation page and try downloading without checking to see validation.

## Miscellaneous Notes
I titled the page Confirm Details for now, but if need be you should change it to something else.