### PR TITLE
feat: add new donations form

### DIFF
--- a/src/api/donor/private-mutations.ts
+++ b/src/api/donor/private-mutations.ts
@@ -1,7 +1,8 @@
 import db from "@/db";
+import { donations } from "@/db/schema";
 import { donors } from "@/db/schema/donor";
 import { Result } from "@/types/result";
-import { Donor, NewDonor } from "@/types/schema";
+import { Donor, NewDonation, NewDonor } from "@/types/schema";
 import handleError from "@/utils/handle-error";
 
 export async function insertDonor(donor: NewDonor): Promise<Result<Donor>> {
@@ -14,6 +15,17 @@ export async function insertDonor(donor: NewDonor): Promise<Result<Donor>> {
     }
 
     return [newDonor, null];
+  } catch (error) {
+    return [null, handleError(error)];
+  }
+}
+
+export async function insertDonation(
+  donation: NewDonation[],
+): Promise<Result<null>> {
+  try {
+    await db.insert(donations).values(donation);
+    return [null, null];
   } catch (error) {
     return [null, handleError(error)];
   }

--- a/src/api/donor/public-mutations.ts
+++ b/src/api/donor/public-mutations.ts
@@ -1,10 +1,10 @@
 "use server";
 
 import { Result } from "@/types/result";
-import { Donor, NewDonor } from "@/types/schema";
+import { Donor, NewDonation, NewDonor } from "@/types/schema";
 import getUserSession from "@/utils/auth/get-user-session";
 
-import { insertDonor } from "./private-mutations";
+import { insertDonation, insertDonor } from "./private-mutations";
 
 export async function createDonor(donor: NewDonor): Promise<Result<Donor>> {
   const session = await getUserSession();
@@ -14,4 +14,22 @@ export async function createDonor(donor: NewDonor): Promise<Result<Donor>> {
   }
 
   return await insertDonor(donor);
+}
+
+export async function addDonation(
+  donation: NewDonation,
+): Promise<Result<null>> {
+  const session = await getUserSession();
+
+  if (!session) {
+    return [null, "Unauthorized"];
+  }
+
+  const [, donationError] = await insertDonation([donation]);
+
+  if (donationError) {
+    return [null, donationError];
+  }
+
+  return [null, null];
 }

--- a/src/app/donor-dashboard/page.tsx
+++ b/src/app/donor-dashboard/page.tsx
@@ -3,6 +3,7 @@ import { ReactNode } from "react";
 
 import { getAllDonorTotals } from "@/api/donor/queries";
 import DonorTable from "@/components/donor/donor-table";
+import DonorProvider from "@/providers/donor-provider";
 
 export default async function DonorDashboardPage(): Promise<ReactNode> {
   const [donorTotals, error] = await getAllDonorTotals();
@@ -29,7 +30,9 @@ export default async function DonorDashboardPage(): Promise<ReactNode> {
         alignItems: "center",
       }}
     >
-      <DonorTable donorTotals={donorTotals} />
+      <DonorProvider initialDonorTotals={donorTotals}>
+        <DonorTable />
+      </DonorProvider>
     </Box>
   );
 }

--- a/src/components/donor/donor-table/add-donations-form.tsx
+++ b/src/components/donor/donor-table/add-donations-form.tsx
@@ -1,0 +1,208 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import EditIcon from "@mui/icons-material/Edit";
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  InputAdornment,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { enqueueSnackbar } from "notistack";
+import { ReactNode, useMemo, useState } from "react";
+import { Controller, useForm } from "react-hook-form";
+import z from "zod";
+
+import { addDonation } from "@/api/donor/public-mutations";
+import { useDonorContext } from "@/providers/donor-provider";
+import { DonorTotal } from "@/types/donor-total";
+import { currencyColor } from "@/utils/money/currency-color";
+import { formatCurrency } from "@/utils/money/format-currency";
+
+const AddDonationFormSchema = z.object({
+  amount: z.number().min(0, "Amount must be at least 0"),
+});
+
+type AddDonationFormValues = z.infer<typeof AddDonationFormSchema>;
+
+type AddDonationFormProps = {
+  total: DonorTotal;
+};
+
+export default function AddDonationForm({
+  total,
+}: AddDonationFormProps): ReactNode {
+  const [isOpen, setIsOpen] = useState(false);
+  const { setDonorTotals } = useDonorContext();
+  const {
+    control,
+    watch,
+    reset,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<AddDonationFormValues>({
+    resolver: zodResolver(AddDonationFormSchema),
+    defaultValues: { amount: 0 },
+  });
+  const fullName = `${total.donor.firstName} ${total.donor.lastName}`;
+
+  const amount = watch("amount");
+
+  const newDonationTotal = useMemo(() => {
+    return Number(total.total) + Number(amount || 0);
+  }, [amount, total.total]);
+
+  const onSubmit = async (data: AddDonationFormValues): Promise<void> => {
+    const [, error] = await addDonation({
+      donorId: total.donor.id,
+      amount: String(data.amount),
+    });
+
+    if (error) {
+      console.error("Failed to add transaction:", error);
+      return;
+    }
+
+    if (error) {
+      enqueueSnackbar(
+        `Failed to add donation of $${data.amount} to ${fullName}. Please try again.`,
+        {
+          variant: "error",
+        },
+      );
+      return;
+    }
+
+    const successMessage = `Added donation of $${data.amount} for ${fullName} successfully!`;
+
+    enqueueSnackbar(successMessage, {
+      variant: "success",
+    });
+
+    setDonorTotals((prevDonations) => {
+      return prevDonations.map((b) => {
+        if (b.donor.id === total.donor.id) {
+          return { ...b, total: newDonationTotal };
+        }
+        return b;
+      });
+    });
+
+    handleClose();
+  };
+
+  const handleOpen = (): void => {
+    setIsOpen(true);
+    reset();
+  };
+
+  const handleClose = (): void => {
+    setIsOpen(false);
+    reset();
+  };
+
+  return (
+    <>
+      <IconButton onClick={handleOpen}>
+        <EditIcon />
+      </IconButton>
+
+      <Dialog open={isOpen} fullWidth maxWidth="xs">
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <DialogTitle variant="h5" sx={{ p: 2, textAlign: "center" }}>
+            Add Donation Form
+          </DialogTitle>
+          <DialogContent>
+            <Typography sx={{ mb: 2 }}>Donor: {fullName}</Typography>
+            <Controller
+              name="amount"
+              control={control}
+              rules={{ required: true, min: 0 }}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  label="Amount"
+                  type="number"
+                  error={!!errors.amount}
+                  helperText={errors.amount?.message}
+                  fullWidth
+                  margin="dense"
+                  slotProps={{
+                    input: {
+                      startAdornment: (
+                        <InputAdornment position="start">$</InputAdornment>
+                      ),
+                    },
+                  }}
+                  onChange={(event) => {
+                    field.onChange(Number(event.target.value) || "");
+                  }}
+                />
+              )}
+            />
+
+            <Box
+              sx={{
+                border: "1px solid #ccc",
+                borderRadius: 2,
+                overflow: "hidden",
+              }}
+            >
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell align="center">Current Donation Total</TableCell>
+                    <TableCell align="center">New Donation Total</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  <TableRow>
+                    <TableCell
+                      align="center"
+                      sx={{ color: currencyColor(total.total) }}
+                    >
+                      {formatCurrency(total.total)}
+                    </TableCell>
+                    <TableCell
+                      align="center"
+                      sx={{ color: currencyColor(newDonationTotal) }}
+                    >
+                      {formatCurrency(newDonationTotal)}
+                    </TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </Box>
+          </DialogContent>
+
+          <DialogActions sx={{ p: 2, justifyContent: "space-between" }}>
+            <Button
+              variant="outlined"
+              onClick={handleClose}
+              sx={{ width: "45%" }}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="contained"
+              color="primary"
+              sx={{ width: "45%" }}
+            >
+              Submit
+            </Button>
+          </DialogActions>
+        </form>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/donor/donor-table/index.tsx
+++ b/src/components/donor/donor-table/index.tsx
@@ -5,15 +5,13 @@ import { ReactNode, useEffect, useMemo, useState } from "react";
 
 import SearchBox from "@/components/common/search-box";
 import AddDonorForm from "@/components/donor/add-donor-form";
+import { useDonorContext } from "@/providers/donor-provider";
 import { DonorTotal } from "@/types/donor-total";
 import { currencyColor } from "@/utils/money/currency-color";
 import { formatCurrency } from "@/utils/money/format-currency";
 
+import AddDonationForm from "./add-donations-form";
 import BulkEmailButton from "./bulk-email-button";
-
-type DonorTableProps = {
-  donorTotals: DonorTotal[];
-};
 
 type Row = {
   id: string;
@@ -22,6 +20,7 @@ type Row = {
   phoneNumber: string | null;
   email: string | null;
   total: number;
+  donorTotal: DonorTotal;
 };
 
 function getRows(donorTotals: DonorTotal[], searchQuery: string): Row[] {
@@ -32,6 +31,7 @@ function getRows(donorTotals: DonorTotal[], searchQuery: string): Row[] {
     phoneNumber: donor.phoneNumber,
     email: donor.email,
     total,
+    donorTotal: { donor, total },
   }));
 
   return rows.filter((row) => {
@@ -43,9 +43,8 @@ function getRows(donorTotals: DonorTotal[], searchQuery: string): Row[] {
   });
 }
 
-export default function DonorTable({
-  donorTotals,
-}: DonorTableProps): ReactNode {
+export default function DonorTable(): ReactNode {
+  const { donorTotals } = useDonorContext();
   const [searchQuery, setSearchQuery] = useState("");
   const [rowSelectionModel, setRowSelectionModel] =
     useState<GridRowSelectionModel>();
@@ -68,6 +67,16 @@ export default function DonorTable({
           {formatCurrency(params.row.total)}
         </Typography>
       ),
+    },
+    {
+      field: "actions",
+      headerName: "",
+      sortable: false,
+      filterable: false,
+      width: 75,
+      align: "center",
+      display: "flex",
+      renderCell: (params) => <AddDonationForm total={params.row.donorTotal} />,
     },
   ];
 

--- a/src/providers/donor-provider.tsx
+++ b/src/providers/donor-provider.tsx
@@ -1,0 +1,45 @@
+"use client";
+import {
+  createContext,
+  Dispatch,
+  ReactNode,
+  SetStateAction,
+  useContext,
+  useState,
+} from "react";
+
+import { DonorTotal } from "@/types/donor-total";
+
+type DonorContextType = {
+  donorTotals: DonorTotal[];
+  setDonorTotals: Dispatch<SetStateAction<DonorTotal[]>>;
+};
+
+const DonorContext = createContext<DonorContextType | undefined>(undefined);
+
+type DonorProviderProps = {
+  children: ReactNode;
+  initialDonorTotals: DonorTotal[];
+};
+
+export default function DonorProvider({
+  children,
+  initialDonorTotals,
+}: DonorProviderProps): ReactNode {
+  const [donorTotals, setDonorTotals] =
+    useState<DonorTotal[]>(initialDonorTotals);
+
+  return (
+    <DonorContext.Provider value={{ donorTotals, setDonorTotals }}>
+      {children}
+    </DonorContext.Provider>
+  );
+}
+
+export const useDonorContext = (): DonorContextType => {
+  const context = useContext(DonorContext);
+  if (!context) {
+    throw new Error("useDonorContext must be used within a DonorProvider");
+  }
+  return context;
+};


### PR DESCRIPTION
# Description
I added a button to add new donations for donors in the donor table. It works basically the same as the rent table form.

## Relevant Issues
#104 
 
## How to Test
Go to donor dashboard and add donations for some donors and then it should show the new donation total after you submit. You can also check the database to see that it adds the donations there as well. 

## Miscellaneous Notes
I kept the color of the donation amounts green on the form  (since they are positive amounts and it works the way the rent form works where positive is green) cause I thought black looked a little too monotone, but feel free to change it if needed.